### PR TITLE
 Add timezone parameter to scan-result endpoint

### DIFF
--- a/docs/endpoints/scan-results.md
+++ b/docs/endpoints/scan-results.md
@@ -45,14 +45,27 @@ The body must contain all collected data from the client's device.
 ```
 
 ### Response
-The response is a summary of the received results.
+The response is an indication of success. When the request was accepted, you will receive an HTTP-status of"204 No Content".
+If the provided `instance_ref` does not exist in the Sensimity database a HTTP-status "400 Bad Request".
+
+#### Status code
+
+If the request was successful:
+
+* 204 No Content
+
+In case of client error:
+
+* 400 Bad Request
+
 
 #### Body
+In case the instance_ref was not recognized:
 
 ```json
 {
-  "message": "The scan results are successfully processed.",
-  "added": 2,
-  "skipped": 0
+  "errors": [
+    "Supplied reference does not exist"
+  ]
 }
 ```

--- a/docs/endpoints/scan-results.md
+++ b/docs/endpoints/scan-results.md
@@ -24,25 +24,30 @@ The body must contain all collected data from the client's device.
   },
   "beaconLogs": [
     {
-      "major": 16,
       "UUID": "44c0ffee-988a-49dc-0bad-a55c0de2d1e4",
+      "major": 16,
+      "minor": 0,
       "timestamp": 1406804464.128,
+      "timezone": "UTC+01:00",
       "rssi": -60,
-      "id": 1,
       "minor": 0,
       "beacon_id": 16
     }, {
-      "major": 16,
       "UUID": "44c0ffee-988a-49dc-0bad-a55c0de2d1e4",
-      "timestamp": 1406804474.128,
-      "rssi": -60,
-      "id": 2,
+      "major": 16,
       "minor": 0,
+      "timestamp": 1406804474.128,
+      "timezone": "UTC+02:00",
+      "rssi": -60,
       "beacon_id": 16
     }
   ]
 }
 ```
+
+| Parameter             | Description                         | Required |
+|-----------------------|-------------------------------------|:--------:|
+| beaconLogs[].timezone | The client's timezone in UTC format | no       |
 
 ### Response
 The response is an indication of success. When the request was accepted, you will receive an HTTP-status of"204 No Content".


### PR DESCRIPTION
To improve the accuracy of statistics we will add the option to specify a timezone per scan result.
This will be implemented over the coming days.

Builds on #3 
